### PR TITLE
Reducing redundancy in assigning directories...

### DIFF
--- a/echo/optimize.py
+++ b/echo/optimize.py
@@ -242,7 +242,13 @@ def prepare_pbs_launch_script(hyper_config: str, model_config: str) -> List[str]
             for opt in val:
                 pbs_options.append(f"#PBS -{arg} {opt}")
         elif len(arg) == 1:
-            pbs_options.append(f"#PBS -{arg} {val}")
+            if arg in ["o", "e"]:
+                if hyper_config["save_path"] in val:
+                    pbs_options.append(f"#PBS -{arg} {val}")
+                elif hyper_config["save_path"] not in val:
+                    pbs_options.append(f"#PBS -{arg} {hyper_config['save_path']+val}")
+            else:
+                pbs_options.append(f"#PBS -{arg} {val}")
         elif arg in ["o", "e"]:
             if val != "/dev/null":
                 _val = os.path.append(hyper_config["save_path"], val)


### PR DESCRIPTION
Currently, the directories for `save_path`, error file name (batch job script), and output file name (batch job script) have to be updated for different `echo/optuna` studies, creating possible workflow failures if a minor typo is made. This update allows us to just set the error file and output file names to something like `out` and allow echo to append it to the already defined `save_path`.