### PR TITLE
Add random forest option for partial dependence

### DIFF
--- a/echo/src/partial_dependence.py
+++ b/echo/src/partial_dependence.py
@@ -48,15 +48,15 @@ def partial_dep(fn, input_cols, output_col, verbose=0, model_type='rf'):
     )
 
     #     xscaler = #StandardScaler()
-    yscaler = StandardScaler()
+    #     yscaler = StandardScaler()
 
     #     x_train = xscaler.fit_transform(x_train)
     #     x_valid = xscaler.transform(x_valid)
     #     x_test = xscaler.transform(x_test)
 
-    y_train = yscaler.fit_transform(np.expand_dims(y_train, -1))
-    y_valid = yscaler.transform(np.expand_dims(y_valid, -1))
-    y_test = yscaler.transform(np.expand_dims(y_test, -1))
+    #     y_train = yscaler.fit_transform(np.expand_dims(y_train, -1))
+    #     y_valid = yscaler.transform(np.expand_dims(y_valid, -1))
+    #     y_test = yscaler.transform(np.expand_dims(y_test, -1))
 
     if model_type=='xgb':
         xgb_model = xgb.XGBRegressor(


### PR DESCRIPTION
@djgagne @jsschreck Following our discussion on the MILES slack about the behavior of XGBoost sometimes generating negative values in partial dependence plots, I've attempted to update the code to add a random forest option. I set it up to use RF as the default, but that could be changed. I tested this with an existing echo run, and the PD plots are comparable to those produced with XGB, but still generating negative values which I'm not sure makes sense for these metrics. [Here](https://docs.google.com/presentation/d/1noQLFlN6g9eFbbdV-n0sL5LhApoFrZ7ExXFW5dPJB5U/edit?usp=sharing) are some example comparisons using a set of metrics from @mariajmolina - noting the vcorr_cust metric is likely out of date, but the valid_mae and vmse_extreme_outp should be relevant (and I believe should not have negative values).

I welcome comments/suggestions on any of the above, plus how best to let users choose between the two options, in addition to general comments about how the RF model is configured (e.g., hyperparameters).