### PR TITLE
Update report.py for multiobj param saving

### DIFF
--- a/echo/optimize.py
+++ b/echo/optimize.py
@@ -277,9 +277,9 @@ def prepare_pbs_launch_script(hyper_config: str, model_config: str) -> List[str]
         logging.warning(
             "Check the log and stdout/err files if simulations are dying to see the errors"
         )
-        for copy in range(hyper_config["pbs"]["trials_per_job"]):
+        for iter_, copy in enumerate(range(hyper_config["pbs"]["trials_per_job"])):
             pbs_options.append(
-                f"{aiml_path} {sys.argv[1]} {sys.argv[2]} -n {pbs_jobid} &"
+                f"CUDA_VISIBLE_DEVICES={iter_}, {aiml_path} {sys.argv[1]} {sys.argv[2]} -n {pbs_jobid} &"
             )
             # allow some time between calling instances of run
             pbs_options.append("sleep 0.5")

--- a/echo/report.py
+++ b/echo/report.py
@@ -75,7 +75,16 @@ def args():
         default=1,
         help="For multi-objective studies, return the k best trials on the Pareto front. Default is 1.",
     )
-
+    
+    parser.add_argument(
+        "-g",
+        "--grab_k",
+        dest="grabk",
+        type=int,
+        default=0,
+        help="For multi-objective studies, return the g trial params on the Pareto front. Default is 0.",
+    )
+    
     return vars(parser.parse_args())
 
 
@@ -175,6 +184,7 @@ def main():
 
     """ Options for multi-objective studies"""
     top_k = args_dict.pop("topk")
+    grab_k = args_dict.pop("grabk")
 
     """ Check if hyperparameter config file exists """
     assert os.path.isfile(
@@ -269,9 +279,9 @@ def main():
     """ Save best parameters to new model configuration """
     # How to handle custom updates?
     if model_config:
-        best_fn = os.path.join(save_path, "best.yml")
+        best_fn = os.path.join(save_path, f"best_{str(grab_k)}.yml")
         logging.info(f"Saving the best model configuration to {best_fn}")
-        best_params = study.best_params if single_objective else best_trials[0].params
+        best_params = study.best_params if single_objective else best_trials[grab_k].params
         hyperparameters = hyper_config["optuna"]["parameters"]
         updated = []
         for named_parameter, _ in hyperparameters.items():


### PR DESCRIPTION
Adding a new flag option for `echo-report` to allow saving of different hyperparameter/model yaml files for models along the pareto front.