### PR TITLE
Initial support for farming out trials on >1 GPUs per node

### DIFF
--- a/echo/examples/keras/hyperparameter.yml
+++ b/echo/examples/keras/hyperparameter.yml
@@ -3,7 +3,8 @@ save_path: "./data"
 
 pbs:
   jobs: 1
-  trials_per_job: 1
+  tasks_per_worker: 1
+  gpus_per_node: 1
   bash: ["source ~/.bashrc", "conda activate echo"]
   batch:
     l: ["select=1:ncpus=8:ngpus=1:mem=64GB", "walltime=12:00:00"]

--- a/echo/examples/torch/hyperparameter.yml
+++ b/echo/examples/torch/hyperparameter.yml
@@ -3,7 +3,8 @@ save_path: "./data"
 
 pbs:
   jobs: 1
-  trials_per_job: 1
+  tasks_per_worker: 1
+  gpus_per_node: 1
   bash: ["source ~/.bashrc", "conda activate echo"]
   batch:
     l: ["select=1:ncpus=8:ngpus=1:mem=64GB", "walltime=12:00:00"]

--- a/echo/optimize.py
+++ b/echo/optimize.py
@@ -206,21 +206,21 @@ def generate_batch_commands(
         # Get the list of GPU devices, or convert a single integer to a list
         gpus_per_node = list(range(hyper_config[batch_type]["gpus_per_node"]))
         
-        # Check if "trials_per_job" is specified in hyper_config[batch_type]
+        # Check if "tasks_per_worker" is specified in hyper_config[batch_type]
         if (
-            "trials_per_job" in hyper_config[batch_type]
-            and hyper_config[batch_type]["trials_per_job"] > 1
+            "tasks_per_worker" in hyper_config[batch_type]
+            and hyper_config[batch_type]["tasks_per_worker"] > 1
         ):
-            # Warn about the experimental nature of trials_per_job
+            # Warn about the experimental nature of tasks_per_worker
             logging.warning(
-                "The trials_per_job is experimental; be advised that some runs may fail."
+                "The tasks_per_worker is experimental; be advised that some runs may fail."
             )
             logging.warning(
                 "Check the log and stdout/err files if simulations are dying to see the errors."
             )
 
             # Loop over the specified number of trials
-            for copy in range(hyper_config[batch_type]["trials_per_job"]):
+            for copy in range(hyper_config[batch_type]["tasks_per_worker"]):
                 # Loop over each GPU device
                 for device in gpus_per_node:
                     # Append the command with CUDA_VISIBLE_DEVICES={device} to batch_commands
@@ -239,10 +239,10 @@ def generate_batch_commands(
                     f"CUDA_VISIBLE_DEVICES={device}, {aiml_path} {sys.argv[1]} {sys.argv[2]} -n {jobid}"
                 )
     elif (
-        "trials_per_job" in hyper_config[batch_type]
-        and hyper_config[batch_type]["trials_per_job"] > 1
+        "tasks_per_worker" in hyper_config[batch_type]
+        and hyper_config[batch_type]["tasks_per_worker"] > 1
     ):
-        # Warn about the experimental nature of trials_per_job
+        # Warn about the experimental nature of tasks_per_worker
         logging.warning(
             "The trails_per_job is experimental, be advised that some runs may fail."
         )
@@ -250,7 +250,7 @@ def generate_batch_commands(
             "Check the log and stdout/err files if simulations are dying to see the errors."
         )
         # Loop over the specified number of trials
-        for copy in range(hyper_config[batch_type]["trials_per_job"]):
+        for copy in range(hyper_config[batch_type]["tasks_per_worker"]):
             # Append the command to batch_commands
             batch_commands.append(
                 f"{aiml_path} {sys.argv[1]} {sys.argv[2]} -n {jobid} &"


### PR DESCRIPTION
What still needs to me updated are the names of the config params: trials_per_job, and the newly added gpus_per_node. trials_per_job simply duplicates the number of python calls, which is multiplied by gpus_per_node (if >=1). What else should we name trials_per_job so its less ambiguous? 