### PR TITLE
Bug Fixes in echo-opt and echo-report

### DIFF
--- a/echo/src/partial_dependence.py
+++ b/echo/src/partial_dependence.py
@@ -70,13 +70,13 @@ def partial_dep(fn, input_cols, output_col, verbose=0, model_type='rf'):
             gamma=gamma,
             subsample=subsample,
             n_jobs=n_jobs,
+            early_stopping_rounds=10,
         )
 
         xgb_model.fit(
             x_train,
             y_train,
             eval_set=[(x_valid, y_valid)],
-            early_stopping_rounds=10,
             verbose=verbose,
         )
 

--- a/echo/src/partial_dependence.py
+++ b/echo/src/partial_dependence.py
@@ -148,7 +148,7 @@ def plot_partial_dependence(f, metrics, save_path, verbose=0, model_type='rf'):
         for k, feature in enumerate(features):
             pd_result = partial_dependence(model, X, feature, grid_resolution=50)
             x = pd_result["average"]
-            y = pd_result["values"]
+            y = pd_result["grid_values"]
             
             if input_cols[k] in hot:
                 

--- a/echo/src/reporting.py
+++ b/echo/src/reporting.py
@@ -70,13 +70,13 @@ def get_sec(time_str):
 def successful_trials(study):
     total_completed_trials = 0
     for trial in study.get_trials():
-        if str(trial.state) in ["TrialState.COMPLETE", "TrialState.PRUNED"]:
+        if str(trial.state.name) in ["COMPLETE", "PRUNED"]:
             total_completed_trials += 1
     return total_completed_trials
 
 
 def trial_report(study):
-    states = [t.state for t in study.get_trials()]
+    states = [t.state.name for t in study.get_trials()]
     state_histo = Counter(states)
     return state_histo
 


### PR DESCRIPTION
Fixed bugs related to old versions of `scikit-learn` and `xgboost` for partial dependence plots.
In echo-report, I changed the `trial_report` to return the state names instead of the numeric id. 
I also changed `echo-opt` to accept absolute or relative paths when calling `echo-opt hyper_config model_config` rather than in the directory where configs are located.